### PR TITLE
Add ctor to support custom communication channel

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -370,7 +370,6 @@ namespace uPLibrary.Networking.M2Mqtt
         }
 #endif
 
-#if BROKER
         /// <summary>
         /// Constructor
         /// </summary>
@@ -390,6 +389,7 @@ namespace uPLibrary.Networking.M2Mqtt
             this.ClientId = null;
             this.CleanSession = true;
 
+            this.syncEndReceiving = new AutoResetEvent(false);
             this.keepAliveEvent = new AutoResetEvent(false);
 
             // queue for handling inflight messages (publishing and acknowledge)
@@ -404,7 +404,6 @@ namespace uPLibrary.Networking.M2Mqtt
             // session
             this.session = null;
         }
-#endif
 
         /// <summary>
         /// MqttClient initialization


### PR DESCRIPTION
Add ctor for injection of different communication channels.

I tested the code and it works without problems on my local machine. This patch allows to use the GnatMQ broker and the M2MQTT client on the same machine.