### PR TITLE
Expose ctor to support custom communication channels

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -370,7 +370,6 @@ namespace uPLibrary.Networking.M2Mqtt
         }
 #endif
 
-#if BROKER
         /// <summary>
         /// Constructor
         /// </summary>
@@ -390,6 +389,7 @@ namespace uPLibrary.Networking.M2Mqtt
             this.ClientId = null;
             this.CleanSession = true;
 
+            this.syncEndReceiving = new AutoResetEvent(false);
             this.keepAliveEvent = new AutoResetEvent(false);
 
             // queue for handling inflight messages (publishing and acknowledge)
@@ -404,7 +404,6 @@ namespace uPLibrary.Networking.M2Mqtt
             // session
             this.session = null;
         }
-#endif
 
         /// <summary>
         /// MqttClient initialization


### PR DESCRIPTION
Expose the existing ctor for `MqttClient` to allow injection of custom communication channels. This allows for example running _GnatMQ_ and _M2MQTT_ on the same machine using a _in-memory_ channel.

Signed-off-by: Christian Kratky <christian.kratky@googlemail.com>