### PR TITLE
Stop creating a new thread during reconnect

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -639,7 +639,8 @@ namespace uPLibrary.Networking.M2Mqtt
 #if BROKER
         public void Close()
 #else
-        private void Close()
+	// fix
+        public void Close()
 #endif
         {
             // stop receiving thread
@@ -1590,6 +1591,8 @@ namespace uPLibrary.Networking.M2Mqtt
                     {
                         // wake up thread that will notify connection is closing
                         this.OnConnectionClosing();
+			// fix
+			break;
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
When mqtt broker is unreachable, every reconnect attempt will create a new thread (ReceiveThread)
https://github.com/eclipse/paho.mqtt.m2mqtt/issues/13