### PR TITLE
Add csproj & VSCode tasks file for .NET Standard 2.0 build

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "taskName": "build",
+            "command": "dotnet build M2Mqtt/M2Mqtt.NetS.csproj",
+            "args": [],
+            "type": "shell",
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/M2Mqtt/M2Mqtt.NetS.csproj
+++ b/M2Mqtt/M2Mqtt.NetS.csproj
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>8.0.30703</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{A11AEF5A-B246-4FE8-8330-06DB73CC8074}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>uPLibrary.Networking.M2Mqtt</RootNamespace>
+    <AssemblyName>M2Mqtt.Net</AssemblyName>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <FileAlignment>512</FileAlignment>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>../bin/Debug/M2Mqtt.NetS</OutputPath>
+    <DefineConstants>TRACE;DEBUG;SSL</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>../bin/Release/M2Mqtt.NetS</OutputPath>
+    <DefineConstants>TRACE;SSL</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Exceptions/MqttClientException.cs" />
+    <Compile Include="Exceptions/MqttCommunicationException.cs" />
+    <Compile Include="Exceptions/MqttConnectionException.cs" />
+    <Compile Include="Exceptions/MqttTimeoutException.cs" />
+    <Compile Include="IMqttNetworkChannel.cs" />
+    <Compile Include="Internal/InternalEvent.cs" />
+    <Compile Include="Internal/MsgInternalEvent.cs" />
+    <Compile Include="Internal/MsgPublishedInternalEvent.cs" />
+    <Compile Include="Messages/MqttMsgBase.cs" />
+    <Compile Include="Messages/MqttMsgConnack.cs" />
+    <Compile Include="Messages/MqttMsgConnect.cs" />
+    <Compile Include="Messages/MqttMsgConnectEventArgs.cs" />
+    <Compile Include="Messages/MqttMsgContext.cs" />
+    <Compile Include="Messages/MqttMsgDisconnect.cs" />
+    <Compile Include="Messages/MqttMsgPingReq.cs" />
+    <Compile Include="Messages/MqttMsgPingResp.cs" />
+    <Compile Include="Messages/MqttMsgPuback.cs" />
+    <Compile Include="Messages/MqttMsgPubcomp.cs" />
+    <Compile Include="Messages/MqttMsgPublish.cs" />
+    <Compile Include="Messages/MqttMsgPublishedEventArgs.cs" />
+    <Compile Include="Messages/MqttMsgPublishEventArgs.cs" />
+    <Compile Include="Messages/MqttMsgPubrec.cs" />
+    <Compile Include="Messages/MqttMsgPubrel.cs" />
+    <Compile Include="Messages/MqttMsgSuback.cs" />
+    <Compile Include="Messages/MqttMsgSubscribe.cs" />
+    <Compile Include="Messages/MqttMsgSubscribedEventArgs.cs" />
+    <Compile Include="Messages/MqttMsgSubscribeEventArgs.cs" />
+    <Compile Include="Messages/MqttMsgUnsuback.cs" />
+    <Compile Include="Messages/MqttMsgUnsubscribe.cs" />
+    <Compile Include="Messages/MqttMsgUnsubscribedEventArgs.cs" />
+    <Compile Include="Messages/MqttMsgUnsubscribeEventArgs.cs" />
+    <Compile Include="MqttClient.cs" />
+    <Compile Include="MqttSecurity.cs" />
+    <Compile Include="Net/MqttNetworkChannel.cs" />
+    <Compile Include="Net/Fx.cs" />
+    <Compile Include="MqttSettings.cs" />
+    <Compile Include="Session/MqttBrokerSession.cs" />
+    <Compile Include="Session/MqttClientSession.cs" />
+    <Compile Include="Session/MqttSession.cs" />
+    <Compile Include="Utility/Trace.cs" />
+    <Compile Include="Utility/QueueExtension.cs" />
+  </ItemGroup>
+  <!--<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
This commit adds the necessary files to build on .NET Standard 2.0 in Visual Studio Code.
Note that the NetS project will not show up in Visual Studio, as I have not added it to the solution yet. I tried to do that, but I ran into problems with Visual Studio not recognising the .NET Core 2.0 framework.