### PR TITLE
Fixed multiple sockets on MqttClient Connect auth fail (#62)

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -598,7 +598,11 @@ namespace uPLibrary.Networking.M2Mqtt
                 Fx.StartThread(this.ProcessInflightThread);
 
                 this.IsConnected = true;
-            }
+            }else
+	    {
+	      Close();
+	    }
+		
             return connack.ReturnCode;
         }
 


### PR DESCRIPTION
Fixed Auth Failed problem on Connect method that caused multiple unclosed sockets. Thanks to @s4v4g3 for the suggestion