### PR TITLE
New Connect override method.

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -481,6 +481,18 @@ namespace uPLibrary.Networking.M2Mqtt
             return this.Connect(clientId, null, null, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, true, MqttMsgConnect.KEEP_ALIVE_PERIOD_DEFAULT);
         }
 
+	/// <summary>
+        /// Connect to broker
+        /// </summary>
+        /// <param name="clientId">Client identifier</param>
+        /// <param name="cleanSession">Clean sessione flag</param>
+        /// <returns>Return code of CONNACK message from broker</returns>
+        public byte Connect(string clientId,
+            bool cleanSession)
+        {
+            return this.Connect(clientId, null, null, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, cleanSession, MqttMsgConnect.KEEP_ALIVE_PERIOD_DEFAULT);
+        }
+	    
         /// <summary>
         /// Connect to broker
         /// </summary>


### PR DESCRIPTION
It recently emerged on our platform the necessity to disable the Clean Session functionality, but unfortunately there is no override method for Connect() which would only take in clientId and cleanSession as arguments. From our testing, the connection attempt fails when passing null username and password, so we can't use any of the existing override methods. The reason why the Connect() method can succefully connect when passing the clientId as the only argument (hence username and password will be null) is still unclear.