### PR TITLE
Overloaded Connect method and accepting password in byte format.

### DIFF
--- a/M2Mqtt/Messages/MqttMsgConnect.cs
+++ b/M2Mqtt/Messages/MqttMsgConnect.cs
@@ -205,6 +205,8 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
         private string username;
         // password
         private string password;
+        // password
+        private byte[] passwordInByte;
         // clean session flag
         private bool cleanSession;
         // keep alive period (in sec)
@@ -251,7 +253,8 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
             string willMessage,
             bool cleanSession,
             ushort keepAlivePeriod,
-            byte protocolVersion
+            byte protocolVersion,
+            byte[] passwordInBytes = null
             )
         {
             this.type = MQTT_MSG_CONNECT_TYPE;
@@ -269,7 +272,10 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
             // [v.3.1.1] added new protocol name and version
             this.protocolVersion = protocolVersion;
             this.protocolName = (this.protocolVersion == PROTOCOL_VERSION_V3_1_1) ? PROTOCOL_NAME_V3_1_1 : PROTOCOL_NAME_V3_1;
+            this.passwordInByte = passwordInBytes;
         }
+
+        
 
         /// <summary>
         /// Parse bytes for a CONNECT message
@@ -388,6 +394,7 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
                 Array.Copy(buffer, index, passwordUtf8, 0, passwordUtf8Length);
                 index += passwordUtf8Length;
                 msg.password = new String(Encoding.UTF8.GetChars(passwordUtf8));
+
             }
 
             return msg;
@@ -406,7 +413,8 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
             byte[] willTopicUtf8 = (this.willFlag && (this.willTopic != null)) ? Encoding.UTF8.GetBytes(this.willTopic) : null;
             byte[] willMessageUtf8 = (this.willFlag && (this.willMessage != null)) ? Encoding.UTF8.GetBytes(this.willMessage) : null;
             byte[] usernameUtf8 = ((this.username != null) && (this.username.Length > 0)) ? Encoding.UTF8.GetBytes(this.username) : null;
-            byte[] passwordUtf8 = ((this.password != null) && (this.password.Length > 0)) ? Encoding.UTF8.GetBytes(this.password) : null;
+            byte[] passwordUtf8 = ((this.password != null) && (this.password.Length > 0)) ? Encoding.UTF8.GetBytes(this.password)
+                : (((this.passwordInByte != null) && (this.passwordInByte.Length > 0)) ?  this.passwordInByte : null);
 
             // [v3.1.1]
             if (this.protocolVersion == PROTOCOL_VERSION_V3_1_1)

--- a/M2Mqtt/Messages/MqttMsgConnect.cs
+++ b/M2Mqtt/Messages/MqttMsgConnect.cs
@@ -205,6 +205,8 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
         private string username;
         // password
         private string password;
+        // password in byte format
+        private byte[] passwordInBytes;
         // clean session flag
         private bool cleanSession;
         // keep alive period (in sec)
@@ -251,7 +253,8 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
             string willMessage,
             bool cleanSession,
             ushort keepAlivePeriod,
-            byte protocolVersion
+            byte protocolVersion,
+            byte[] passwordInBytes = null
             )
         {
             this.type = MQTT_MSG_CONNECT_TYPE;
@@ -269,7 +272,10 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
             // [v.3.1.1] added new protocol name and version
             this.protocolVersion = protocolVersion;
             this.protocolName = (this.protocolVersion == PROTOCOL_VERSION_V3_1_1) ? PROTOCOL_NAME_V3_1_1 : PROTOCOL_NAME_V3_1;
+            this.passwordInBytes = passwordInBytes;
         }
+
+        
 
         /// <summary>
         /// Parse bytes for a CONNECT message
@@ -387,7 +393,8 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
                 passwordUtf8 = new byte[passwordUtf8Length];
                 Array.Copy(buffer, index, passwordUtf8, 0, passwordUtf8Length);
                 index += passwordUtf8Length;
-                msg.password = new String(Encoding.UTF8.GetChars(passwordUtf8));
+                msg.password = Convert.ToBase64String(passwordUtf8);
+                
             }
 
             return msg;
@@ -406,7 +413,8 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
             byte[] willTopicUtf8 = (this.willFlag && (this.willTopic != null)) ? Encoding.UTF8.GetBytes(this.willTopic) : null;
             byte[] willMessageUtf8 = (this.willFlag && (this.willMessage != null)) ? Encoding.UTF8.GetBytes(this.willMessage) : null;
             byte[] usernameUtf8 = ((this.username != null) && (this.username.Length > 0)) ? Encoding.UTF8.GetBytes(this.username) : null;
-            byte[] passwordUtf8 = ((this.password != null) && (this.password.Length > 0)) ? Encoding.UTF8.GetBytes(this.password) : null;
+            byte[] passwordUtf8 = ((this.password != null) && (this.password.Length > 0)) ? Encoding.UTF8.GetBytes(this.password)
+                : (((this.passwordInBytes != null) && (this.passwordInBytes.Length > 0)) ?  this.passwordInBytes : null);
 
             // [v3.1.1]
             if (this.protocolVersion == PROTOCOL_VERSION_V3_1_1)

--- a/M2Mqtt/Messages/MqttMsgConnect.cs
+++ b/M2Mqtt/Messages/MqttMsgConnect.cs
@@ -205,8 +205,6 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
         private string username;
         // password
         private string password;
-        // password in byte format
-        private byte[] passwordInBytes;
         // clean session flag
         private bool cleanSession;
         // keep alive period (in sec)
@@ -253,8 +251,7 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
             string willMessage,
             bool cleanSession,
             ushort keepAlivePeriod,
-            byte protocolVersion,
-            byte[] passwordInBytes = null
+            byte protocolVersion
             )
         {
             this.type = MQTT_MSG_CONNECT_TYPE;
@@ -272,10 +269,7 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
             // [v.3.1.1] added new protocol name and version
             this.protocolVersion = protocolVersion;
             this.protocolName = (this.protocolVersion == PROTOCOL_VERSION_V3_1_1) ? PROTOCOL_NAME_V3_1_1 : PROTOCOL_NAME_V3_1;
-            this.passwordInBytes = passwordInBytes;
         }
-
-        
 
         /// <summary>
         /// Parse bytes for a CONNECT message
@@ -393,8 +387,7 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
                 passwordUtf8 = new byte[passwordUtf8Length];
                 Array.Copy(buffer, index, passwordUtf8, 0, passwordUtf8Length);
                 index += passwordUtf8Length;
-                msg.password = Convert.ToBase64String(passwordUtf8);
-                
+                msg.password = new String(Encoding.UTF8.GetChars(passwordUtf8));
             }
 
             return msg;
@@ -413,8 +406,7 @@ namespace uPLibrary.Networking.M2Mqtt.Messages
             byte[] willTopicUtf8 = (this.willFlag && (this.willTopic != null)) ? Encoding.UTF8.GetBytes(this.willTopic) : null;
             byte[] willMessageUtf8 = (this.willFlag && (this.willMessage != null)) ? Encoding.UTF8.GetBytes(this.willMessage) : null;
             byte[] usernameUtf8 = ((this.username != null) && (this.username.Length > 0)) ? Encoding.UTF8.GetBytes(this.username) : null;
-            byte[] passwordUtf8 = ((this.password != null) && (this.password.Length > 0)) ? Encoding.UTF8.GetBytes(this.password)
-                : (((this.passwordInBytes != null) && (this.passwordInBytes.Length > 0)) ?  this.passwordInBytes : null);
+            byte[] passwordUtf8 = ((this.password != null) && (this.password.Length > 0)) ? Encoding.UTF8.GetBytes(this.password) : null;
 
             // [v3.1.1]
             if (this.protocolVersion == PROTOCOL_VERSION_V3_1_1)

--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -513,6 +513,20 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="clientId">Client identifier</param>
         /// <param name="username">Username</param>
         /// <param name="password">Password</param>
+        /// <returns>Return code of CONNACK message from broker</returns>
+        public byte Connect(string clientId,
+            string username,
+            byte[] password)
+        {
+            return this.Connect(clientId, username, null, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, true, MqttMsgConnect.KEEP_ALIVE_PERIOD_DEFAULT, password);
+        }
+
+        /// <summary>
+        /// Connect to broker
+        /// </summary>
+        /// <param name="clientId">Client identifier</param>
+        /// <param name="username">Username</param>
+        /// <param name="password">Password</param>
         /// <param name="cleanSession">Clean sessione flag</param>
         /// <param name="keepAlivePeriod">Keep alive period</param>
         /// <returns>Return code of CONNACK message from broker</returns>
@@ -523,6 +537,24 @@ namespace uPLibrary.Networking.M2Mqtt
             ushort keepAlivePeriod)
         {
             return this.Connect(clientId, username, password, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, cleanSession, keepAlivePeriod);
+        }
+
+        /// <summary>
+        /// Connect to broker
+        /// </summary>
+        /// <param name="clientId">Client identifier</param>
+        /// <param name="username">Username</param>
+        /// <param name="password">Password</param>
+        /// <param name="cleanSession">Clean sessione flag</param>
+        /// <param name="keepAlivePeriod">Keep alive period</param>
+        /// <returns>Return code of CONNACK message from broker</returns>
+        public byte Connect(string clientId,
+            string username,
+            byte[] password,
+            bool cleanSession,
+            ushort keepAlivePeriod)
+        {
+            return this.Connect(clientId, username, null, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, cleanSession, keepAlivePeriod, password);
         }
 
         /// <summary>
@@ -548,7 +580,9 @@ namespace uPLibrary.Networking.M2Mqtt
             string willTopic,
             string willMessage,
             bool cleanSession,
-            ushort keepAlivePeriod)
+            ushort keepAlivePeriod,
+            byte[] passwordInBytes = null
+            )
         {
             // create CONNECT message
             MqttMsgConnect connect = new MqttMsgConnect(clientId,
@@ -561,7 +595,8 @@ namespace uPLibrary.Networking.M2Mqtt
                 willMessage,
                 cleanSession,
                 keepAlivePeriod,
-                (byte)this.ProtocolVersion);
+                (byte)this.ProtocolVersion,
+                passwordInBytes);
 
             try
             {

--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -513,20 +513,6 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="clientId">Client identifier</param>
         /// <param name="username">Username</param>
         /// <param name="password">Password</param>
-        /// <returns>Return code of CONNACK message from broker</returns>
-        public byte Connect(string clientId,
-            string username,
-            byte[] password)
-        {
-            return this.Connect(clientId, username, null, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, true, MqttMsgConnect.KEEP_ALIVE_PERIOD_DEFAULT, password);
-        }
-
-        /// <summary>
-        /// Connect to broker
-        /// </summary>
-        /// <param name="clientId">Client identifier</param>
-        /// <param name="username">Username</param>
-        /// <param name="password">Password</param>
         /// <param name="cleanSession">Clean sessione flag</param>
         /// <param name="keepAlivePeriod">Keep alive period</param>
         /// <returns>Return code of CONNACK message from broker</returns>
@@ -537,24 +523,6 @@ namespace uPLibrary.Networking.M2Mqtt
             ushort keepAlivePeriod)
         {
             return this.Connect(clientId, username, password, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, cleanSession, keepAlivePeriod);
-        }
-
-        /// <summary>
-        /// Connect to broker
-        /// </summary>
-        /// <param name="clientId">Client identifier</param>
-        /// <param name="username">Username</param>
-        /// <param name="password">Password</param>
-        /// <param name="cleanSession">Clean sessione flag</param>
-        /// <param name="keepAlivePeriod">Keep alive period</param>
-        /// <returns>Return code of CONNACK message from broker</returns>
-        public byte Connect(string clientId,
-            string username,
-            byte[] password,
-            bool cleanSession,
-            ushort keepAlivePeriod)
-        {
-            return this.Connect(clientId, username, null, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, cleanSession, keepAlivePeriod, password);
         }
 
         /// <summary>
@@ -580,9 +548,7 @@ namespace uPLibrary.Networking.M2Mqtt
             string willTopic,
             string willMessage,
             bool cleanSession,
-            ushort keepAlivePeriod,
-            byte[] passwordInBytes = null
-            )
+            ushort keepAlivePeriod)
         {
             // create CONNECT message
             MqttMsgConnect connect = new MqttMsgConnect(clientId,
@@ -595,8 +561,7 @@ namespace uPLibrary.Networking.M2Mqtt
                 willMessage,
                 cleanSession,
                 keepAlivePeriod,
-                (byte)this.ProtocolVersion,
-                passwordInBytes);
+                (byte)this.ProtocolVersion);
 
             try
             {


### PR DESCRIPTION
It is enhancement request.

Currently, password for connect method is being sent in plain text format. With connect overload method, password can be encrypted and sent in byte format.

This fork project is tested with and without overloaded connect method.

Signed-off-by: Dhanvin Shah <dhanvin.shah@gmail.com>
‌