### PR TITLE
Set threads as background so they close automatically with the client

### DIFF
--- a/M2Mqtt/Net/Fx.cs
+++ b/M2Mqtt/Net/Fx.cs
@@ -25,7 +25,7 @@ namespace uPLibrary.Networking.M2Mqtt
     {
         public static void StartThread(ThreadStart threadStart)
         {
-            new Thread(threadStart).Start();
+            new Thread(threadStart) { IsBackground = true }.Start();
         }
 
         public static void SleepThread(int millisecondsTimeout)


### PR DESCRIPTION
If I try to connect a client without a username and password when it's required, there are threads running that prevent my application from shutting down properly. Starting threads in background mode (so they close automatically with the client) fixes this.