### PR TITLE
Changed returntype of the Connect() function from byte to the complete Connack Message - Only way to termine the existence of the persistent session

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -476,7 +476,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// </summary>
         /// <param name="clientId">Client identifier</param>
         /// <returns>Return code of CONNACK message from broker</returns>
-        public byte Connect(string clientId)
+        public MqttMsgConnack Connect(string clientId)
         {
             return this.Connect(clientId, null, null, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, true, MqttMsgConnect.KEEP_ALIVE_PERIOD_DEFAULT);
         }
@@ -487,7 +487,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="clientId">Client identifier</param>
         /// <param name="cleanSession">Clean sessione flag</param>
         /// <returns>Return code of CONNACK message from broker</returns>
-        public byte Connect(string clientId,
+        public MqttMsgConnack Connect(string clientId,
             bool cleanSession)
         {
             return this.Connect(clientId, null, null, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, cleanSession, MqttMsgConnect.KEEP_ALIVE_PERIOD_DEFAULT);
@@ -500,7 +500,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="username">Username</param>
         /// <param name="password">Password</param>
         /// <returns>Return code of CONNACK message from broker</returns>
-        public byte Connect(string clientId,
+        public MqttMsgConnack Connect(string clientId,
             string username,
             string password)
         {
@@ -516,7 +516,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="cleanSession">Clean sessione flag</param>
         /// <param name="keepAlivePeriod">Keep alive period</param>
         /// <returns>Return code of CONNACK message from broker</returns>
-        public byte Connect(string clientId,
+        public MqttMsgConnack Connect(string clientId,
             string username,
             string password,
             bool cleanSession,
@@ -539,7 +539,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="cleanSession">Clean sessione flag</param>
         /// <param name="keepAlivePeriod">Keep alive period</param>
         /// <returns>Return code of CONNACK message from broker</returns>
-        public byte Connect(string clientId,
+        public MqttMsgConnack Connect(string clientId,
             string username,
             string password,
             bool willRetain,
@@ -611,7 +611,7 @@ namespace uPLibrary.Networking.M2Mqtt
 
                 this.IsConnected = true;
             }
-            return connack.ReturnCode;
+            return connack;
         }
 
         /// <summary>


### PR DESCRIPTION
The Code of the Client and MqttMsgConnack class already got changed to support the sessionPresent flag of mqtt v3.1.1.
But there is no way to get this flag, because the connect function just returns the return code and not the complete connack message.
This flag is very useful when working with persistent sessions to determine if a session already exists or every topic should be subscribed. (double subscription also works but if you have any retained messages (as I do) they'll get pulled twice)