### PR TITLE
Changed returntype of the Connect() function from byte to the complete Connack Message - Only way to determine the existence of the persistent session

### DIFF
--- a/M2Mqtt/MqttClient.cs
+++ b/M2Mqtt/MqttClient.cs
@@ -475,7 +475,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// Connect to broker
         /// </summary>
         /// <param name="clientId">Client identifier</param>
-        /// <returns>Return code of CONNACK message from broker</returns>
+        /// <returns>CONNACK message from broker</returns>
         public MqttMsgConnack Connect(string clientId)
         {
             return this.Connect(clientId, null, null, false, MqttMsgConnect.QOS_LEVEL_AT_MOST_ONCE, false, null, null, true, MqttMsgConnect.KEEP_ALIVE_PERIOD_DEFAULT);
@@ -486,7 +486,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// </summary>
         /// <param name="clientId">Client identifier</param>
         /// <param name="cleanSession">Clean sessione flag</param>
-        /// <returns>Return code of CONNACK message from broker</returns>
+        /// <returns>CONNACK message from broker</returns>
         public MqttMsgConnack Connect(string clientId,
             bool cleanSession)
         {
@@ -499,7 +499,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="clientId">Client identifier</param>
         /// <param name="username">Username</param>
         /// <param name="password">Password</param>
-        /// <returns>Return code of CONNACK message from broker</returns>
+        /// <returns>CONNACK message from broker</returns>
         public MqttMsgConnack Connect(string clientId,
             string username,
             string password)
@@ -515,7 +515,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="password">Password</param>
         /// <param name="cleanSession">Clean sessione flag</param>
         /// <param name="keepAlivePeriod">Keep alive period</param>
-        /// <returns>Return code of CONNACK message from broker</returns>
+        /// <returns>CONNACK message from broker</returns>
         public MqttMsgConnack Connect(string clientId,
             string username,
             string password,
@@ -538,7 +538,7 @@ namespace uPLibrary.Networking.M2Mqtt
         /// <param name="willMessage">Will message</param>
         /// <param name="cleanSession">Clean sessione flag</param>
         /// <param name="keepAlivePeriod">Keep alive period</param>
-        /// <returns>Return code of CONNACK message from broker</returns>
+        /// <returns>CONNACK message from broker</returns>
         public MqttMsgConnack Connect(string clientId,
             string username,
             string password,


### PR DESCRIPTION
The Code of the Client and MqttMsgConnack class already got changed to support the sessionPresent flag of mqtt v3.1.1. 
But there is no way to get this flag, because the connect function just returns the return code and not the complete connack message. 
This flag is very useful when working with persistent sessions to determine if a session already exists or every topic should be subscribed. (double subscription also works but if you have any retained messages (as I do) they'll get pulled twice)